### PR TITLE
Add derive macro to strip enum of data

### DIFF
--- a/quork-proc/Cargo.toml
+++ b/quork-proc/Cargo.toml
@@ -21,3 +21,6 @@ proc-macro-error = "1.0"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
+
+[dev-dependencies]
+strum = { version = "0.25.0", features = ["derive"] }

--- a/quork-proc/Cargo.toml
+++ b/quork-proc/Cargo.toml
@@ -15,6 +15,7 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+heck = { version = "0.4.1", features = ["unicode"] }
 proc-macro-crate = "2.0"
 proc-macro-error = "1.0"
 proc-macro2 = "1.0"

--- a/quork-proc/Cargo.toml
+++ b/quork-proc/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-heck = { version = "0.5" }
+heck = "0.5"
 proc-macro-crate = "3.1"
 proc-macro-error2 = "2.0"
 proc-macro2 = "1.0"

--- a/quork-proc/Cargo.toml
+++ b/quork-proc/Cargo.toml
@@ -15,7 +15,6 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-heck = "0.5"
 proc-macro-crate = "3.1"
 proc-macro-error2 = "2.0"
 proc-macro2 = "1.0"

--- a/quork-proc/Cargo.toml
+++ b/quork-proc/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-heck = { version = "0.4.1", features = ["unicode"] }
+heck = { version = "0.5" }
 proc-macro-crate = "3.1"
 proc-macro-error2 = "2.0"
 proc-macro2 = "1.0"
@@ -23,4 +23,4 @@ quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
 
 [dev-dependencies]
-strum = { version = "0.25.0", features = ["derive"] }
+strum = { version = "0.26", features = ["derive"] }

--- a/quork-proc/src/lib.rs
+++ b/quork-proc/src/lib.rs
@@ -18,7 +18,7 @@ mod time_fn;
 #[macro_use]
 extern crate quote;
 
-#[proc_macro_derive(Strip, attributes(strip))]
+#[proc_macro_derive(Strip, attributes(strip, ignore))]
 #[proc_macro_error]
 pub fn strip_enum(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);

--- a/quork-proc/src/lib.rs
+++ b/quork-proc/src/lib.rs
@@ -18,7 +18,8 @@ mod time_fn;
 #[macro_use]
 extern crate quote;
 
-#[proc_macro_derive(Strip)]
+#[proc_macro_derive(Strip, attributes(strip))]
+#[proc_macro_error]
 pub fn strip_enum(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
 

--- a/quork-proc/src/lib.rs
+++ b/quork-proc/src/lib.rs
@@ -18,7 +18,7 @@ mod time_fn;
 #[macro_use]
 extern crate quote;
 
-#[proc_macro_derive(Strip, attributes(stripped_ident, stripped_meta, ignore))]
+#[proc_macro_derive(Strip, attributes(stripped_ident, stripped_meta, stripped_ignore))]
 #[proc_macro_error]
 pub fn strip_enum(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);

--- a/quork-proc/src/lib.rs
+++ b/quork-proc/src/lib.rs
@@ -18,7 +18,7 @@ mod time_fn;
 #[macro_use]
 extern crate quote;
 
-#[proc_macro_derive(Strip, attributes(strip, ignore))]
+#[proc_macro_derive(Strip, attributes(stripped_ident, stripped_meta, ignore))]
 #[proc_macro_error]
 pub fn strip_enum(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);

--- a/quork-proc/src/lib.rs
+++ b/quork-proc/src/lib.rs
@@ -3,6 +3,7 @@
 #![warn(clippy::pedantic)]
 #![warn(missing_docs)]
 
+use proc_macro::TokenStream;
 use proc_macro_error::proc_macro_error;
 use syn::{parse_macro_input, DeriveInput, LitStr};
 
@@ -11,15 +12,23 @@ mod enum_list;
 mod from_tuple;
 mod new;
 mod strip;
+mod strip_enum;
 mod time_fn;
 
 #[macro_use]
 extern crate quote;
 
+#[proc_macro_derive(Strip)]
+pub fn strip_enum(input: TokenStream) -> TokenStream {
+    let ast = parse_macro_input!(input as DeriveInput);
+
+    strip_enum::strip_enum(&ast).into()
+}
+
 /// Implement [`quork::ListVariants`] for enums
 #[proc_macro_derive(ListVariants)]
 #[proc_macro_error]
-pub fn derive_enum_list(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn derive_enum_list(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     enum_list::enum_list(&ast).into()
 }
@@ -29,7 +38,7 @@ pub fn derive_enum_list(input: proc_macro::TokenStream) -> proc_macro::TokenStre
 ///
 /// Converts an enum variant to a string literal, within a constant context.
 #[proc_macro_derive(ConstStr)]
-pub fn derive_const_str(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn derive_const_str(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     const_str::derive(&ast).into()
 }
@@ -39,7 +48,7 @@ pub fn derive_const_str(input: proc_macro::TokenStream) -> proc_macro::TokenStre
 /// Will follow the form of `new(field: Type, ...) -> Self`, where all fields are required.
 #[proc_macro_derive(New)]
 #[proc_macro_error]
-pub fn derive_new(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn derive_new(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     new::derive(&ast).into()
 }
@@ -47,7 +56,7 @@ pub fn derive_new(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// Implement the [`std::convert::From`] trait for converting tuples into tuple structs
 #[proc_macro_derive(FromTuple)]
 #[proc_macro_error]
-pub fn derive_from_tuple(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn derive_from_tuple(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
     from_tuple::derive(&ast).into()
 }
@@ -59,10 +68,7 @@ pub fn derive_from_tuple(input: proc_macro::TokenStream) -> proc_macro::TokenStr
 /// You can pass "s", "ms", "ns"
 #[proc_macro_attribute]
 #[proc_macro_error]
-pub fn time(
-    args: proc_macro::TokenStream,
-    input: proc_macro::TokenStream,
-) -> proc_macro::TokenStream {
+pub fn time(args: TokenStream, input: TokenStream) -> TokenStream {
     let args_str = args.to_string();
     let fmt = match args_str.as_str() {
         "ms" | "milliseconds" => time_fn::TimeFormat::Milliseconds,
@@ -74,7 +80,7 @@ pub fn time(
 
 /// Strip whitespace from the right of a string literal on each line
 #[proc_macro]
-pub fn strip_lines(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn strip_lines(input: TokenStream) -> TokenStream {
     let literal = parse_macro_input!(input as LitStr);
 
     strip::funclike(&literal, &strip::Alignment::None).into()
@@ -82,7 +88,7 @@ pub fn strip_lines(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
 /// Strip whitespace from the left and right of a string literal on each line
 #[proc_macro]
-pub fn rstrip_lines(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn rstrip_lines(input: TokenStream) -> TokenStream {
     let literal = parse_macro_input!(input as LitStr);
 
     strip::funclike(&literal, &strip::Alignment::Right).into()
@@ -90,7 +96,7 @@ pub fn rstrip_lines(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
 /// Strip whitespace from the left of a string literal on each line
 #[proc_macro]
-pub fn lstrip_lines(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+pub fn lstrip_lines(input: TokenStream) -> TokenStream {
     let literal = parse_macro_input!(input as LitStr);
 
     strip::funclike(&literal, &strip::Alignment::Left).into()

--- a/quork-proc/src/lib.rs
+++ b/quork-proc/src/lib.rs
@@ -19,7 +19,7 @@ mod time_fn;
 extern crate quote;
 
 /// Create an additional enum with all values stripped
-#[proc_macro_derive(Strip, attributes(stripped))]
+#[proc_macro_derive(Strip, attributes(stripped_meta, stripped))]
 #[proc_macro_error]
 pub fn strip_enum(input: TokenStream) -> TokenStream {
     let mut ast = parse_macro_input!(input as DeriveInput);

--- a/quork-proc/src/lib.rs
+++ b/quork-proc/src/lib.rs
@@ -18,12 +18,13 @@ mod time_fn;
 #[macro_use]
 extern crate quote;
 
-#[proc_macro_derive(Strip, attributes(stripped_ident, stripped_meta, stripped_ignore))]
+/// Create an additional enum with all values stripped
+#[proc_macro_derive(Strip, attributes(stripped))]
 #[proc_macro_error]
 pub fn strip_enum(input: TokenStream) -> TokenStream {
-    let ast = parse_macro_input!(input as DeriveInput);
+    let mut ast = parse_macro_input!(input as DeriveInput);
 
-    strip_enum::strip_enum(&ast).into()
+    strip_enum::strip_enum(&mut ast).into()
 }
 
 /// Implement [`quork::ListVariants`] for enums

--- a/quork-proc/src/strip_enum.rs
+++ b/quork-proc/src/strip_enum.rs
@@ -1,5 +1,64 @@
-use proc_macro2::TokenStream;
+use proc_macro2::{Ident, Span, TokenStream};
+use proc_macro_crate::{crate_name, FoundCrate};
+use proc_macro_error::{abort, abort_call_site};
+use quote::{quote, ToTokens};
+use syn::{spanned::Spanned, DeriveInput};
 
-pub fn strip_enum(ast: &syn::DeriveInput) -> TokenStream {
-    todo!()
+pub fn strip_enum(ast: &DeriveInput) -> TokenStream {
+    let struct_name = {
+        let original_ident = &ast.ident;
+        let og_ident_span = original_ident.span();
+        Ident::new(&format!("{}Hooks", original_ident), og_ident_span)
+    };
+
+    let data = &ast.data;
+
+    let variants = match data {
+        syn::Data::Enum(ref e) => e
+            .variants
+            .iter()
+            .filter_map(|variant| {
+                if variant.attrs.iter().any(|attr| match attr.meta {
+                    syn::Meta::Path(ref p) => p.is_ident("no_hook"),
+                    _ => abort!(
+                        attr.span(),
+                        "Expected path-style (i.e #[no_hook]), found other style attribute macro"
+                    ),
+                }) {
+                    None
+                } else {
+                    Some(variant.ident.to_token_stream())
+                }
+            })
+            .collect::<Vec<_>>(),
+        _ => abort_call_site!("Can only be derived for enums"),
+    };
+
+    let command_names = variants
+        .iter()
+        .map(|variant| heck::AsKebabCase(variant.to_string()).to_string())
+        .collect::<Vec<_>>();
+
+    let strum = match crate_name("strum").expect("strum is present in `Cargo.toml`") {
+        FoundCrate::Itself => Ident::new("strum", Span::call_site()),
+        FoundCrate::Name(name) => Ident::new(&name, Span::call_site()),
+    };
+
+    quote! {
+        // TODO: Better way of doing this? or add support for meta in proc macro
+        #[derive(Debug, Clone, #strum::Display, #strum::IntoStaticStr, #strum::EnumIter, PartialEq, Eq)]
+        #[strum(serialize_all = "kebab-case")]
+        pub enum #struct_name {
+            #(#variants),*
+        }
+
+        impl From<String> for #struct_name {
+            fn from(string: String) -> Self {
+                match string.as_str() {
+                    #(#command_names => #struct_name::#variants,)*
+                    _ => panic!("Invalid command name: {}", string),
+                }
+            }
+        }
+    }
 }

--- a/quork-proc/src/strip_enum.rs
+++ b/quork-proc/src/strip_enum.rs
@@ -1,0 +1,5 @@
+use proc_macro2::TokenStream;
+
+pub fn strip_enum(ast: &syn::DeriveInput) -> TokenStream {
+    todo!()
+}

--- a/quork-proc/src/strip_enum.rs
+++ b/quork-proc/src/strip_enum.rs
@@ -5,10 +5,10 @@ use syn::{spanned::Spanned, DeriveInput, Expr, ExprLit, Lit, Variant};
 
 fn ignore_variant(variant: &Variant) -> bool {
     variant.attrs.iter().any(|attr| match attr.meta {
-        syn::Meta::Path(ref p) => p.is_ident("ignore"),
+        syn::Meta::Path(ref p) => p.is_ident("stripped_ignore"),
         _ => abort!(
             attr.span(),
-            "Expected path-style (i.e #[ignore]), found other style attribute macro"
+            "Expected path-style (i.e #[stripped_ignore]), found other style attribute macro"
         ),
     })
 }

--- a/quork-proc/src/strip_enum.rs
+++ b/quork-proc/src/strip_enum.rs
@@ -76,8 +76,8 @@ pub fn strip_enum(ast: &DeriveInput) -> TokenStream {
                 .filter(|attr| !attr.path().is_ident("stripped_meta"));
 
             let meta = meta_attrs
-                .map(|attr| match &attr.meta {
-                    syn::Meta::NameValue(meta) => meta.value.clone(),
+                .flat_map(|attr| match &attr.meta {
+                    syn::Meta::List(meta) => meta.parse_args(),
                     _ => abort!(
                         attr.span(),
                         "Expected #[stripped_meta = ...]. Found other style attribute."
@@ -101,7 +101,7 @@ pub fn strip_enum(ast: &DeriveInput) -> TokenStream {
     } = info;
 
     quote! {
-        #(#[#meta])*
+        #(#meta)*
         pub enum #ident {
             #(#variants),*
         }

--- a/quork-proc/src/strip_enum.rs
+++ b/quork-proc/src/strip_enum.rs
@@ -76,12 +76,15 @@ pub fn strip_enum(ast: &DeriveInput) -> TokenStream {
                 .filter(|attr| !attr.path().is_ident("stripped_meta"));
 
             let meta = meta_attrs
-                .flat_map(|attr| match &attr.meta {
-                    syn::Meta::List(meta) => meta.parse_args(),
-                    _ => abort!(
-                        attr.span(),
-                        "Expected #[stripped_meta = ...]. Found other style attribute."
-                    ),
+                .flat_map(|attr| {
+                    panic!();
+                    match &attr.meta {
+                        syn::Meta::List(meta) => meta.parse_args(),
+                        _ => abort!(
+                            attr.span(),
+                            "Expected #[stripped_meta = ...]. Found other style attribute."
+                        ),
+                    }
                 })
                 .collect();
 
@@ -101,7 +104,7 @@ pub fn strip_enum(ast: &DeriveInput) -> TokenStream {
     } = info;
 
     quote! {
-        #(#meta)*
+        #(#[#meta])*
         pub enum #ident {
             #(#variants),*
         }

--- a/quork-proc/src/strip_enum.rs
+++ b/quork-proc/src/strip_enum.rs
@@ -19,11 +19,10 @@ pub fn strip_enum(ast: &DeriveInput) -> TokenStream {
             .iter()
             .filter_map(|variant| {
                 if variant.attrs.iter().any(|attr| match attr.meta {
-                    // TODO: Any point checking this?
-                    syn::Meta::Path(ref p) => p.is_ident("strip"),
+                    syn::Meta::Path(ref p) => p.is_ident("ignore"),
                     _ => abort!(
                         attr.span(),
-                        "Expected path-style (i.e #[no_hook]), found other style attribute macro"
+                        "Expected path-style (i.e #[ignore]), found other style attribute macro"
                     ),
                 }) {
                     None
@@ -32,7 +31,7 @@ pub fn strip_enum(ast: &DeriveInput) -> TokenStream {
                 }
             })
             .collect::<Vec<_>>(),
-        _ => abort_call_site!("Can only be derived for enums"),
+        _ => abort_call_site!("`Strip` can only be derived for enums"),
     };
 
     let command_names = variants

--- a/quork-proc/src/strip_enum.rs
+++ b/quork-proc/src/strip_enum.rs
@@ -41,9 +41,9 @@ pub fn strip_enum(ast: &DeriveInput) -> TokenStream {
                 .iter()
                 .find(|attr| attr.path().is_ident("stripped_ident"))
             {
-                match info_attr.meta {
+                match &info_attr.meta {
                     syn::Meta::NameValue(name_value) => {
-                        let ident = name_value.value;
+                        let ident = &name_value.value;
 
                         if let syn::Expr::Lit(ExprLit {
                             lit: Lit::Str(string),

--- a/quork-proc/src/strip_enum.rs
+++ b/quork-proc/src/strip_enum.rs
@@ -64,7 +64,10 @@ pub fn strip_enum(ast: &DeriveInput) -> TokenStream {
                     ),
                 }
             } else {
-                ast.ident.clone()
+                Ident::new(
+                    &format!("{}Stripped", ast.ident.to_string()),
+                    ast.ident.span(),
+                )
             };
 
             StrippedData {

--- a/quork-proc/src/strip_enum.rs
+++ b/quork-proc/src/strip_enum.rs
@@ -84,6 +84,7 @@ pub fn strip_enum(ast: &DeriveInput) -> TokenStream {
                 .iter()
                 .filter(|attr| attr.path().is_ident("stripped_meta"))
                 .map(|attr| match &attr.meta {
+                    // TODO: Add inherit metadata
                     syn::Meta::List(meta) => meta.parse_args().expect("single meta attribute"),
                     _ => abort!(
                         attr.span(),

--- a/quork-proc/src/strip_enum.rs
+++ b/quork-proc/src/strip_enum.rs
@@ -19,7 +19,8 @@ pub fn strip_enum(ast: &DeriveInput) -> TokenStream {
             .iter()
             .filter_map(|variant| {
                 if variant.attrs.iter().any(|attr| match attr.meta {
-                    syn::Meta::Path(ref p) => p.is_ident("no_hook"),
+                    // TODO: Any point checking this?
+                    syn::Meta::Path(ref p) => p.is_ident("strip"),
                     _ => abort!(
                         attr.span(),
                         "Expected path-style (i.e #[no_hook]), found other style attribute macro"

--- a/quork-proc/src/strip_enum.rs
+++ b/quork-proc/src/strip_enum.rs
@@ -20,6 +20,16 @@ struct StrippedData {
     meta: Vec<Expr>,
 }
 
+struct MetaArgs {
+    meta: Vec<Expr>,
+}
+
+impl Parse for MetaArgs {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        // input.peek3(token)
+    }
+}
+
 pub fn strip_enum(ast: &DeriveInput) -> TokenStream {
     let data = &ast.data;
     let attrs = &ast.attrs;
@@ -73,18 +83,15 @@ pub fn strip_enum(ast: &DeriveInput) -> TokenStream {
 
             let meta_attrs = attrs
                 .iter()
-                .filter(|attr| !attr.path().is_ident("stripped_meta"));
+                .filter(|attr| attr.path().is_ident("stripped_meta"));
 
             let meta = meta_attrs
-                .flat_map(|attr| {
-                    panic!();
-                    match &attr.meta {
-                        syn::Meta::List(meta) => meta.parse_args(),
-                        _ => abort!(
-                            attr.span(),
-                            "Expected #[stripped_meta = ...]. Found other style attribute."
-                        ),
-                    }
+                .flat_map(|attr| match &attr.meta {
+                    syn::Meta::List(meta) => syn::parse2::<Vec<Expr>>(meta.tokens),
+                    _ => abort!(
+                        attr.span(),
+                        "Expected #[stripped_meta(...)]. Found other style attribute."
+                    ),
                 })
                 .collect();
 
@@ -96,6 +103,8 @@ pub fn strip_enum(ast: &DeriveInput) -> TokenStream {
         }
         _ => abort_call_site!("`Strip` can only be derived for enums"),
     };
+
+    panic!("{:?}", info.meta);
 
     let StrippedData {
         ident,

--- a/quork-proc/src/strip_enum.rs
+++ b/quork-proc/src/strip_enum.rs
@@ -71,19 +71,15 @@ pub fn strip_enum(ast: &mut DeriveInput) -> TokenStream {
 
             let (new_ident, meta_list) = if let Some(info_attr_pos) = attrs
                 .iter()
-                .position(|attr| attr.path().is_ident("stripped_ident"))
+                .position(|attr| attr.path().is_ident("stripped"))
             {
                 let info_attr = attrs.remove(info_attr_pos);
 
                 let mut new_ident: Option<Ident> = None;
-                let mut meta_list = Vec::<syn::Meta>::new();
 
                 let ident_parser = syn::meta::parser(|meta| {
                     if meta.path.is_ident("ident") {
                         new_ident = Some(meta.value()?.parse()?);
-                        Ok(())
-                    } else if meta.path.is_ident("meta") {
-                        meta_list.push(meta.value()?.parse()?);
                         Ok(())
                     } else {
                         Err(meta.error("unsupported stripped property"))
@@ -113,6 +109,8 @@ pub fn strip_enum(ast: &mut DeriveInput) -> TokenStream {
         meta,
         vis,
     } = info;
+
+    // panic!("{:?}", meta);
 
     quote! {
         #(#meta)*

--- a/quork-proc/src/strip_enum.rs
+++ b/quork-proc/src/strip_enum.rs
@@ -97,7 +97,7 @@ pub fn strip_enum(ast: &mut DeriveInput) -> TokenStream {
                 .iter()
                 .filter(|attr| attr.path().is_ident("stripped_meta"))
                 .map(|meta_attr| match meta_attr.meta {
-                    Meta::List(_) => meta_attr.meta.clone(),
+                    Meta::List(ref meta_data) => meta_data.parse_args::<syn::Meta>().unwrap(),
                     _ => abort!(
                         meta_attr.span(),
                         "Expected #[stripped_meta(...)]. Found other style attribute."

--- a/quork-proc/src/strip_enum.rs
+++ b/quork-proc/src/strip_enum.rs
@@ -1,7 +1,7 @@
 use proc_macro2::{Ident, TokenStream};
 use proc_macro_error2::{abort, abort_call_site};
 use quote::{quote, ToTokens};
-use syn::{spanned::Spanned, DeriveInput, Meta, MetaNameValue, Variant, Visibility};
+use syn::{spanned::Spanned, DeriveInput, Meta, Variant, Visibility};
 
 fn ignore_variant(variant: &Variant) -> bool {
     variant.attrs.iter().any(|attr| match attr.meta {

--- a/quork-proc/src/strip_enum.rs
+++ b/quork-proc/src/strip_enum.rs
@@ -93,22 +93,17 @@ pub fn strip_enum(ast: &mut DeriveInput) -> TokenStream {
                 default_ident()
             };
 
-            let mut meta_list: Vec<syn::Meta> = vec![];
-
-            if let Some(stripped_meta_pos) = attrs
+            let meta_list: Vec<syn::Meta> = attrs
                 .iter()
-                .position(|attr| attr.path().is_ident("stripped_meta"))
-            {
-                let meta_attr = attrs.remove(stripped_meta_pos);
-
-                match meta_attr.meta {
-                    Meta::List(_) => meta_list.push(meta_attr.meta),
+                .filter(|attr| attr.path().is_ident("stripped_meta"))
+                .map(|meta_attr| match meta_attr.meta {
+                    Meta::List(_) => meta_attr.meta.clone(),
                     _ => abort!(
                         meta_attr.span(),
                         "Expected #[stripped_meta(...)]. Found other style attribute."
                     ),
-                }
-            };
+                })
+                .collect();
 
             StrippedData {
                 ident: new_ident,

--- a/quork-proc/src/strip_enum.rs
+++ b/quork-proc/src/strip_enum.rs
@@ -17,7 +17,13 @@ fn ignore_variant(variant: &Variant) -> bool {
                 }
             });
 
-            list.parse_args_with(list_parser).unwrap();
+            if let Err(err) = list.parse_args_with(list_parser) {
+                abort! {
+                    err.span(),
+                    "Failed to parse stripped attribute: {}", err;
+                    help = "Only supported properties on enum variants are `ignore`"
+                }
+            }
 
             ignored
         }

--- a/quork-proc/tests/strip_enum.rs
+++ b/quork-proc/tests/strip_enum.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::Display;
 
-use strum::{EnumIter, IntoEnumIterator};
+use strum::{Display, EnumIter, IntoEnumIterator};
 
 use quork_proc::Strip;
 
@@ -13,7 +13,7 @@ pub fn enum_to_string<T: IntoEnumIterator + Display>() -> String {
 struct DummyStruct;
 
 #[derive(Strip)]
-#[stripped_meta(derive(EnumIter))]
+#[stripped_meta(derive(EnumIter, Display))]
 enum EnumWithData {
     Test1(DummyStruct),
     Test2(DummyStruct),
@@ -27,6 +27,7 @@ fn has_all_variants() {
 }
 
 #[derive(Strip)]
+#[stripped_meta(derive(EnumIter, Display), strum(serialize_all = "kebab-case"))]
 enum EnumExclude {
     Test1(DummyStruct),
     #[stripped_ignore]

--- a/quork-proc/tests/strip_enum.rs
+++ b/quork-proc/tests/strip_enum.rs
@@ -13,7 +13,7 @@ pub fn enum_to_string<T: IntoEnumIterator + Display>() -> String {
 struct DummyStruct;
 
 #[derive(Strip)]
-#[stripped_meta = derive(EnumIter)]
+#[stripped_meta(derive(EnumIter))]
 enum EnumWithData {
     Test1(DummyStruct),
     Test2(DummyStruct),

--- a/quork-proc/tests/strip_enum.rs
+++ b/quork-proc/tests/strip_enum.rs
@@ -4,17 +4,15 @@ use std::fmt::Display;
 
 use strum::IntoEnumIterator;
 
+use quork_proc::Strip;
+
 pub fn enum_to_string<T: IntoEnumIterator + Display>() -> String {
     T::iter().map(|v| v.to_string()).collect::<String>()
 }
 
-use sfsu_derive::Hooks;
-
-use helpers::enum_to_string;
-
 struct DummyStruct;
 
-#[derive(Hooks)]
+#[derive(Strip)]
 enum EnumWithData {
     Test1(DummyStruct),
     Test2(DummyStruct),
@@ -22,22 +20,22 @@ enum EnumWithData {
 
 #[test]
 fn has_all_variants() {
-    let variants = enum_to_string::<EnumWithDataHooks>();
+    let variants = enum_to_string::<EnumWithDataStripped>();
 
     assert_eq!(variants, "test1test2");
 }
 
-#[derive(Hooks)]
+#[derive(Strip)]
 enum EnumExclude {
     Test1(DummyStruct),
-    #[no_hook]
+    #[stripped_ignore]
     Test2(DummyStruct),
     Test3(DummyStruct),
 }
 
 #[test]
 fn excludes_no_hook_variant() {
-    let variants = enum_to_string::<EnumExcludeHooks>();
+    let variants = enum_to_string::<EnumExcludeStripped>();
 
     assert_eq!(variants, "test1test3");
 }

--- a/quork-proc/tests/strip_enum.rs
+++ b/quork-proc/tests/strip_enum.rs
@@ -14,6 +14,7 @@ struct DummyStruct;
 
 #[derive(Strip)]
 #[stripped_meta(derive(EnumIter, Display))]
+#[stripped_meta(strum(serialize_all = "kebab-case"))]
 enum EnumWithData {
     Test1(DummyStruct),
     Test2(DummyStruct),

--- a/quork-proc/tests/strip_enum.rs
+++ b/quork-proc/tests/strip_enum.rs
@@ -1,0 +1,43 @@
+#![allow(dead_code)]
+
+use std::fmt::Display;
+
+use strum::IntoEnumIterator;
+
+pub fn enum_to_string<T: IntoEnumIterator + Display>() -> String {
+    T::iter().map(|v| v.to_string()).collect::<String>()
+}
+
+use sfsu_derive::Hooks;
+
+use helpers::enum_to_string;
+
+struct DummyStruct;
+
+#[derive(Hooks)]
+enum EnumWithData {
+    Test1(DummyStruct),
+    Test2(DummyStruct),
+}
+
+#[test]
+fn has_all_variants() {
+    let variants = enum_to_string::<EnumWithDataHooks>();
+
+    assert_eq!(variants, "test1test2");
+}
+
+#[derive(Hooks)]
+enum EnumExclude {
+    Test1(DummyStruct),
+    #[no_hook]
+    Test2(DummyStruct),
+    Test3(DummyStruct),
+}
+
+#[test]
+fn excludes_no_hook_variant() {
+    let variants = enum_to_string::<EnumExcludeHooks>();
+
+    assert_eq!(variants, "test1test3");
+}

--- a/quork-proc/tests/strip_enum.rs
+++ b/quork-proc/tests/strip_enum.rs
@@ -27,7 +27,8 @@ fn has_all_variants() {
 }
 
 #[derive(Strip)]
-#[stripped_meta(derive(EnumIter, Display), strum(serialize_all = "kebab-case"))]
+#[stripped_meta(derive(EnumIter, Display))]
+#[stripped_meta(strum(serialize_all = "kebab-case"))]
 enum EnumExclude {
     Test1(DummyStruct),
     #[stripped_ignore]

--- a/quork-proc/tests/strip_enum.rs
+++ b/quork-proc/tests/strip_enum.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::Display;
 
-use strum::IntoEnumIterator;
+use strum::{EnumIter, IntoEnumIterator};
 
 use quork_proc::Strip;
 
@@ -13,6 +13,7 @@ pub fn enum_to_string<T: IntoEnumIterator + Display>() -> String {
 struct DummyStruct;
 
 #[derive(Strip)]
+#[stripped_meta = derive(EnumIter)]
 enum EnumWithData {
     Test1(DummyStruct),
     Test2(DummyStruct),

--- a/quork-proc/tests/strip_enum.rs
+++ b/quork-proc/tests/strip_enum.rs
@@ -13,8 +13,7 @@ pub fn enum_to_string<T: IntoEnumIterator + Display>() -> String {
 struct DummyStruct;
 
 #[derive(Strip)]
-#[stripped_meta(derive(EnumIter, Display))]
-#[stripped_meta(strum(serialize_all = "kebab-case"))]
+#[stripped(meta = derive(EnumIter, Display), meta = strum(serialize_all = "kebab-case"))]
 enum EnumWithData {
     Test1(DummyStruct),
     Test2(DummyStruct),

--- a/quork-proc/tests/strip_enum.rs
+++ b/quork-proc/tests/strip_enum.rs
@@ -13,7 +13,8 @@ pub fn enum_to_string<T: IntoEnumIterator + Display>() -> String {
 struct DummyStruct;
 
 #[derive(Strip)]
-#[stripped(meta = derive(EnumIter, Display), meta = strum(serialize_all = "kebab-case"))]
+#[stripped_meta(derive(EnumIter, Display))]
+#[stripped_meta(strum(serialize_all = "kebab-case"))]
 enum EnumWithData {
     Test1(DummyStruct),
     Test2(DummyStruct),

--- a/quork-proc/tests/strip_enum.rs
+++ b/quork-proc/tests/strip_enum.rs
@@ -32,15 +32,23 @@ fn has_all_variants() {
 #[stripped_meta(strum(serialize_all = "kebab-case"))]
 enum EnumExclude {
     Test1(DummyStruct),
-    #[stripped(notignore)]
+    #[stripped(ignore)]
     Test2(DummyStruct),
     Test3(DummyStruct),
 }
 
-#[derive(Strip, Display)]
+#[derive(Strip)]
 #[stripped_meta(derive(EnumIter))]
 #[stripped_meta(strum(serialize_all = "kebab-case"))]
 enum EnumWithInherit {
+    Test1(DummyStruct),
+}
+
+#[derive(Strip)]
+#[stripped_meta(derive(EnumIter))]
+#[stripped_meta(strum(serialize_all = "kebab-case"))]
+#[stripped(ident = IChoseThisIdent)]
+enum EnumWithCustomIdent {
     Test1(DummyStruct),
 }
 

--- a/quork-proc/tests/strip_enum.rs
+++ b/quork-proc/tests/strip_enum.rs
@@ -32,7 +32,7 @@ fn has_all_variants() {
 #[stripped_meta(strum(serialize_all = "kebab-case"))]
 enum EnumExclude {
     Test1(DummyStruct),
-    #[stripped_ignore]
+    #[stripped(ignore)]
     Test2(DummyStruct),
     Test3(DummyStruct),
 }

--- a/quork-proc/tests/strip_enum.rs
+++ b/quork-proc/tests/strip_enum.rs
@@ -32,7 +32,7 @@ fn has_all_variants() {
 #[stripped_meta(strum(serialize_all = "kebab-case"))]
 enum EnumExclude {
     Test1(DummyStruct),
-    #[stripped(ignore)]
+    #[stripped(notignore)]
     Test2(DummyStruct),
     Test3(DummyStruct),
 }

--- a/quork-proc/tests/strip_enum.rs
+++ b/quork-proc/tests/strip_enum.rs
@@ -37,6 +37,13 @@ enum EnumExclude {
     Test3(DummyStruct),
 }
 
+#[derive(Strip, Display)]
+#[stripped_meta(derive(EnumIter))]
+#[stripped_meta(strum(serialize_all = "kebab-case"))]
+enum EnumWithInherit {
+    Test1(DummyStruct),
+}
+
 #[test]
 fn excludes_no_hook_variant() {
     let variants = enum_to_string::<EnumExcludeStripped>();


### PR DESCRIPTION
- [ ] Option to inherit meta from existing enum

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new procedural macro `strip_enum` for generating stripped enums.
	- Added new enums and functionality for converting enum variants to strings.
- **Bug Fixes**
	- Deprecated certain macros with guidance for users to transition to new alternatives.
- **Chores**
	- Updated development dependencies, including the addition of `strum` for enhanced capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->